### PR TITLE
Change nsteps

### DIFF
--- a/sensor_response_curves/resample.py
+++ b/sensor_response_curves/resample.py
@@ -30,6 +30,6 @@ def resample_response_curves(
             bounds_error=False, fill_value=0)
     start_wv = wavelength[0]
     end_wv = wavelength[-1]
-    nsteps = round((end_wv - start_wv) / 0.0025) + 1
+    nsteps = round((end_wv - start_wv) / resolution) + 1
     xnew = np.linspace(start_wv, end_wv, nsteps)
     return xnew, f(xnew)

--- a/sensor_response_curves/resample.py
+++ b/sensor_response_curves/resample.py
@@ -30,6 +30,6 @@ def resample_response_curves(
             bounds_error=False, fill_value=0)
     start_wv = wavelength[0]
     end_wv = wavelength[-1]
-    nsteps = int((end_wv - start_wv) // resolution + 1)
+    nsteps = round((end_wv - start_wv) / 0.0025) + 1
     xnew = np.linspace(start_wv, end_wv, nsteps)
     return xnew, f(xnew)


### PR DESCRIPTION
Use the same calculation for number of interpolation steps as Py6S does here:
https://github.com/robintw/Py6S/blob/72014c40114ca6d325b4f73542fa65c5b6c7e92d/Py6S/Params/wavelength.py#L108

This fixes https://github.com/DHI-GRAS/bathymetry/issues/336. That bug was due to off-by-one errors introduced by different rounding approaches (actually rounding to closest integer contra truncating).